### PR TITLE
Add --snapshotPrefix flag to send command

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -64,7 +64,7 @@ func ProcessSmartOptions(ctx context.Context, jobInfo *files.JobInfo) error {
 	for i := range snapshots {
 		log.AppLogger.Debugf("Considering snapshot %s", snapshots[i].Name)
 		if !snapshots[i].Bookmark {
-			if (jobInfo.SnapshotPrefix == "" || strings.HasPrefix(snapshots[i].Name, jobInfo.SnapshotPrefix)) {
+			if jobInfo.SnapshotPrefix == "" || strings.HasPrefix(snapshots[i].Name, jobInfo.SnapshotPrefix) {
 				log.AppLogger.Debugf("Matched snapshot: %s", snapshots[i].Name)
 				jobInfo.BaseSnapshot = snapshots[i]
 				break

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -62,9 +62,13 @@ func ProcessSmartOptions(ctx context.Context, jobInfo *files.JobInfo) error {
 	}
 	// Base Snapshots cannot be a bookmark
 	for i := range snapshots {
+		log.AppLogger.Debugf("Considering snapshot %s", snapshots[i].Name)
 		if !snapshots[i].Bookmark {
-			jobInfo.BaseSnapshot = snapshots[i]
-			break
+			if (jobInfo.SnapshotPrefix == "" || strings.HasPrefix(snapshots[i].Name, jobInfo.SnapshotPrefix)) {
+				log.AppLogger.Debugf("Matched snapshot: %s", snapshots[i].Name)
+				jobInfo.BaseSnapshot = snapshots[i]
+				break
+			}
 		}
 	}
 	if jobInfo.BaseSnapshot.Name == "" {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -111,6 +111,12 @@ func init() {
 		false,
 		"set this flag to do an incremental backup of the most recent snapshot from the most recent snapshot found in the target.",
 	)
+	sendCmd.Flags().StringVar(
+		&jobInfo.SnapshotPrefix,
+		"snapshotPrefix",
+		"",
+		"Only consider snapshots starting with the given snapshot prefix",
+	)
 	sendCmd.Flags().DurationVar(
 		&jobInfo.FullIfOlderThan,
 		"fullIfOlderThan",

--- a/files/jobinfo.go
+++ b/files/jobinfo.go
@@ -44,6 +44,7 @@ type JobInfo struct {
 	VolumeName              string
 	BaseSnapshot            SnapshotInfo
 	IncrementalSnapshot     SnapshotInfo
+	SnapshotPrefix          string
 	Compressor              string
 	CompressionLevel        int
 	Separator               string


### PR DESCRIPTION
I use automatic snapshotting, and the most recent snapshot is likely to be a "frequent" snapshot that is short lived.  So I added --snapshotPrefix so I can tell zfsbackup to only use snapshots that match the given prefix.

IE:

```
zfsbackup-go send --snapshotPrefix=zfs-auto-snap_daily
```