### PR TITLE
Added --raw flag to send command for ZFS encrypted datasets

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -77,6 +77,7 @@ func init() {
 	sendCmd.Flags().StringVarP(&jobInfo.IncrementalSnapshot.Name, "incremental", "i", "", "See the -i flag on zfs send for more information")
 	sendCmd.Flags().StringVarP(&fullIncremental, "intermediary", "I", "", "See the -I flag on zfs send for more information")
 	sendCmd.Flags().BoolVarP(&jobInfo.Properties, "properties", "p", false, "See the -p flag on zfs send for more information.")
+	sendCmd.Flags().BoolVarP(&jobInfo.Raw, "raw", "w", false, "See the -w flag on zfs send for more information.")
 
 	// Specific to download only
 	sendCmd.Flags().Uint64Var(

--- a/files/jobinfo.go
+++ b/files/jobinfo.go
@@ -45,6 +45,7 @@ type JobInfo struct {
 	BaseSnapshot            SnapshotInfo
 	IncrementalSnapshot     SnapshotInfo
 	SnapshotPrefix          string
+	Raw                     bool
 	Compressor              string
 	CompressionLevel        int
 	Separator               string

--- a/zfs/zfs.go
+++ b/zfs/zfs.go
@@ -135,6 +135,11 @@ func GetZFSSendCommand(ctx context.Context, j *files.JobInfo) *exec.Cmd {
 		zfsArgs = append(zfsArgs, "-c")
 	}
 
+	if j.Raw {
+		log.AppLogger.Infof("Enabling the raw (-w) flag on the send.")
+		zfsArgs = append(zfsArgs, "-w")
+	}
+
 	if j.IncrementalSnapshot.Name != "" {
 		incrementalName := j.IncrementalSnapshot.Name
 		if j.IncrementalSnapshot.Bookmark {


### PR DESCRIPTION
ZFS 0.8.0 introduced native dataset encryption.[1] This PR adds the `--raw` flag for `zfsbackup send`, allowing encrypted datasets to be sent raw to the destination. Without the `--raw` flag, ZFS-encrypted datasets will be decrypted and stored on the target in plaintext.

[1] https://www.phoronix.com/scan.php?page=news_item&px=ZFS-On-Linux-0.8-Released