### PR TITLE
Fix listobjects pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ zfsbackup*
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+.env
+*.asc

--- a/backends/aws_s3_backend.go
+++ b/backends/aws_s3_backend.go
@@ -373,7 +373,7 @@ func (a *AWSS3Backend) List(ctx context.Context, prefix string) ([]string, error
 		resp, err = a.client.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
 			Bucket:            aws.String(a.bucketName),
 			MaxKeys:           aws.Int64(1000),
-			Prefix:            aws.String(prefix),
+			Prefix:            aws.String(a.prefix + prefix),
 			ContinuationToken: resp.NextContinuationToken,
 		})
 		if err != nil {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -63,7 +63,7 @@ func ProcessSmartOptions(ctx context.Context, jobInfo *files.JobInfo) error {
 	}
 	// Base Snapshots cannot be a bookmark
 	for i := range snapshots {
-		log.AppLogger.Debugf("Considering snapshot %s", snapshots[i].Name)
+		log.AppLogger.Debugf("Base: Considering snapshot %s", snapshots[i].Name)
 		if !snapshots[i].Bookmark {
 			if jobInfo.SnapshotPrefix == "" || strings.HasPrefix(snapshots[i].Name, jobInfo.SnapshotPrefix) {
 				log.AppLogger.Debugf("Matched snapshot: %s", snapshots[i].Name)
@@ -148,6 +148,8 @@ func ProcessSmartOptions(ctx context.Context, jobInfo *files.JobInfo) error {
 		if lastBackup[0].Equal(&snapshots[0]) {
 			return ErrNoOp
 		}
+
+		log.AppLogger.Debugf("Last Comparable Snap: %s", lastComparableSnapshots[0])
 
 		jobInfo.IncrementalSnapshot = *lastBackup[0]
 	}
@@ -235,6 +237,8 @@ func Backup(pctx context.Context, jobInfo *files.JobInfo) error {
 	if fileBufferSize == 0 {
 		fileBufferSize = 1
 	}
+
+	log.AppLogger.Debugf("Base snapshot: %s", jobInfo.BaseSnapshot)
 
 	// Validate the snapshots we want to use exist
 	if ok, verr := validateSnapShotExists(ctx, &jobInfo.BaseSnapshot, jobInfo.VolumeName, false); verr != nil {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -149,15 +149,6 @@ func ProcessSmartOptions(ctx context.Context, jobInfo *files.JobInfo) error {
 			return ErrNoOp
 		}
 
-		if ok, verr := validateSnapShotExists(ctx, lastComparableSnapshots[0], jobInfo.VolumeName, true); verr != nil {
-			return verr
-		} else if !ok {
-			log.AppLogger.Infof(
-				"Last Full backup was done on %v but is no longer found in the local target, performing full backup.",
-				lastComparableSnapshots[0].CreationTime, jobInfo.FullIfOlderThan,
-			)
-			return nil
-		}
 		jobInfo.IncrementalSnapshot = *lastBackup[0]
 	}
 	return nil

--- a/backup/sync.go
+++ b/backup/sync.go
@@ -137,6 +137,7 @@ func syncCache(ctx context.Context, j *files.JobInfo, localCache string, backend
 
 // nolint:unparam // Some errors are not ok to ignore
 func validateSnapShotExists(ctx context.Context, snapshot *files.SnapshotInfo, target string, includeBookmarks bool) (bool, error) {
+	log.AppLogger.Debugf("validate snapshot exists: %s %s", target, snapshot)
 	snapshots, err := zfs.GetSnapshotsAndBookmarks(ctx, target)
 	if err != nil {
 		log.AppLogger.Debugf("Could not list snapshots for %s: %v", target, err)
@@ -148,6 +149,7 @@ func validateSnapShotExists(ctx context.Context, snapshot *files.SnapshotInfo, t
 
 func validateSnapShotExistsFromSnaps(snapshot *files.SnapshotInfo, snapshots []files.SnapshotInfo, includeBookmarks bool) bool {
 	for _, snap := range snapshots {
+		log.AppLogger.Debugf("Considering snapshot: %s", snap)
 		if !includeBookmarks && snap.Bookmark {
 			continue
 		}

--- a/zfs/zfs.go
+++ b/zfs/zfs.go
@@ -146,7 +146,7 @@ func GetZFSSendCommand(ctx context.Context, j *files.JobInfo) *exec.Cmd {
 			zfsArgs = append(zfsArgs, "-I", incrementalName)
 		} else {
 			log.AppLogger.Infof("Enabling an incremental stream (-i) on the send to snapshot %s", incrementalName)
-			zfsArgs = append(zfsArgs, "-i", incrementalName)
+			zfsArgs = append(zfsArgs, "-I", incrementalName)
 		}
 	}
 


### PR DESCRIPTION
the `List` method in the AWS S3 backend is using a different `Prefix` when fetching subsequent pages than the `Prefix` that was used when fetching the first page of results.

This causes an error to be returned by `ListObjectsV2` when it needs to fetch more than one page.

Symptom is that you get S3 errors once there are enough entries in the manifests prefix that it needs to fetch the next page, zfsbackup blows up with an error.

Seems pretty obvious this was just a typo/omission from skim of the code.

Hopefully makes sense.