### PR TITLE
cmd: add skip-missing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Flags:
   -R, --replication                See the -R flag on zfs send for more information
       --resume                     set this flag to true when you want to try and resume a previously cancled or failed backup. It is up to the caller to ensure the same command line arguments are provided between the original backup and the resumed one.
       --separator string           the separator to use between object component names. (default "|")
+  -s, --skip-missing               See the -s flag on zfs send for more information
       --uploadChunkSize int        the chunk size, in MiB, to use when uploading. A minimum of 5MiB and maximum of 100MiB is enforced. (default 10)
       --volsize uint               the maximum size (in MiB) a volume should be before splitting to a new volume. Note: zfsbackup will try its best to stay close/under this limit but it is not garaunteed. (default 200)
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -73,6 +73,7 @@ func init() {
 
 	// ZFS send command options
 	sendCmd.Flags().BoolVarP(&jobInfo.Replication, "replication", "R", false, "See the -R flag on zfs send for more information")
+	sendCmd.Flags().BoolVarP(&jobInfo.SkipMissing, "skip-missing", "s", false, "See the -s flag on zfs send for more information")
 	sendCmd.Flags().BoolVarP(&jobInfo.Deduplication, "deduplication", "D", false, "See the -D flag for zfs send for more information.")
 	sendCmd.Flags().StringVarP(&jobInfo.IncrementalSnapshot.Name, "incremental", "i", "", "See the -i flag on zfs send for more information")
 	sendCmd.Flags().StringVarP(&fullIncremental, "intermediary", "I", "", "See the -I flag on zfs send for more information")
@@ -184,6 +185,7 @@ func ResetSendJobInfo() {
 	resetRootFlags()
 	// ZFS send command options
 	jobInfo.Replication = false
+	jobInfo.SkipMissing = false
 	jobInfo.Deduplication = false
 	jobInfo.IncrementalSnapshot = files.SnapshotInfo{}
 	jobInfo.BaseSnapshot = files.SnapshotInfo{}

--- a/files/jobinfo.go
+++ b/files/jobinfo.go
@@ -55,6 +55,7 @@ type JobInfo struct {
 	EncryptTo               string
 	SignFrom                string
 	Replication             bool
+	SkipMissing             bool
 	Deduplication           bool
 	Properties              bool
 	IntermediaryIncremental bool
@@ -134,6 +135,7 @@ func (j *JobInfo) String() string {
 	output = append(
 		output,
 		fmt.Sprintf("Replication: %v", j.Replication),
+		fmt.Sprintf("SkipMissing: %v", j.SkipMissing),
 		fmt.Sprintf("Archives: %d - %d bytes (%s)", len(j.Volumes), totalWrittenBytes, humanize.IBytes(totalWrittenBytes)),
 		fmt.Sprintf("Volume Size (Raw): %d bytes (%s)", j.ZFSStreamBytes, humanize.IBytes(j.ZFSStreamBytes)),
 		fmt.Sprintf("Uploaded: %v (took %v)\n\n", j.StartTime, j.EndTime.Sub(j.StartTime)),

--- a/zfs/zfs.go
+++ b/zfs/zfs.go
@@ -120,6 +120,11 @@ func GetZFSSendCommand(ctx context.Context, j *files.JobInfo) *exec.Cmd {
 		zfsArgs = append(zfsArgs, "-R")
 	}
 
+	if j.SkipMissing {
+		log.AppLogger.Infof("Enabling the skip-missing (-s) flag on the send.")
+		zfsArgs = append(zfsArgs, "-s")
+	}
+
 	if j.Deduplication {
 		log.AppLogger.Infof("Enabling the deduplication (-D) flag on the send.")
 		zfsArgs = append(zfsArgs, "-D")


### PR DESCRIPTION
This option was added in [openzfs 2.1.0](https://github.com/openzfs/zfs/releases/tag/zfs-2.1.0). Combined with "-R" allows to greatly simplify sending scripts, which can default to sending a whole pool with "-R -s" even if some datasets are not snapshoted