### PR TITLE
added --smartIntermediaryIncremental so that intermediary incremental…

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -160,6 +160,7 @@ func ProcessSmartOptions(ctx context.Context, jobInfo *files.JobInfo) error {
 		}
 		jobInfo.IncrementalSnapshot = *lastBackup[0]
 	}
+	jobInfo.IntermediaryIncremental = jobInfo.SmartIntermediaryIncremental
 	return nil
 }
 

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -177,6 +177,12 @@ func init() {
 		10,
 		"the chunk size, in MiB, to use when uploading. A minimum of 5MiB and maximum of 100MiB is enforced.",
 	)
+	sendCmd.Flags().BoolVar(
+		&jobInfo.SmartIntermediaryIncremental,
+		"smartIntermediaryIncremental",
+		false,
+		"store intermediary snapshots when using smart options",
+	)
 }
 
 // ResetSendJobInfo exists solely for integration testing

--- a/files/jobinfo.go
+++ b/files/jobinfo.go
@@ -39,26 +39,27 @@ var (
 // JobInfo represents the relevant information for a job that can be used to read
 // in details of that job at a later time.
 type JobInfo struct {
-	StartTime               time.Time
-	EndTime                 time.Time
-	VolumeName              string
-	BaseSnapshot            SnapshotInfo
-	IncrementalSnapshot     SnapshotInfo
-	SnapshotPrefix          string
-	Compressor              string
-	CompressionLevel        int
-	Separator               string
-	ZFSCommandLine          string
-	ZFSStreamBytes          uint64
-	Volumes                 []*VolumeInfo
-	Version                 float64
-	EncryptTo               string
-	SignFrom                string
-	Replication             bool
-	Deduplication           bool
-	Properties              bool
-	IntermediaryIncremental bool
-	Resume                  bool `json:"-"`
+	StartTime                    time.Time
+	EndTime                      time.Time
+	VolumeName                   string
+	BaseSnapshot                 SnapshotInfo
+	IncrementalSnapshot          SnapshotInfo
+	SnapshotPrefix               string
+	Compressor                   string
+	CompressionLevel             int
+	Separator                    string
+	ZFSCommandLine               string
+	ZFSStreamBytes               uint64
+	Volumes                      []*VolumeInfo
+	Version                      float64
+	EncryptTo                    string
+	SignFrom                     string
+	Replication                  bool
+	Deduplication                bool
+	Properties                   bool
+	IntermediaryIncremental      bool
+	SmartIntermediaryIncremental bool
+	Resume                       bool `json:"-"`
 	// "Smart" Options
 	Full            bool          `json:"-"`
 	Incremental     bool          `json:"-"`


### PR DESCRIPTION
…s can be backed up when using smart options

If `--smartIntermediaryIncremental` is given then the `zfs send` command will use `-I` in place of `-i` so that intermediary incrementals are also transferred.

I believe that setting `jobInfo.IntermediaryIncremental` to `jobInfo.SmartIntermediaryIncremental` is a simple way to achieve this when processing smart options, but it might be worth a more careful review.

