### PR TITLE
If the zfs command failed then the command hung. by calling maniwg.Do…

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -373,6 +373,8 @@ func Backup(pctx context.Context, jobInfo *files.JobInfo) error {
 				case fileBuffer <- true:
 				}
 			case <-ctx.Done():
+				log.AppLogger.Debugf("manifest copy: ctx.Done(): err = %v", ctx.Err())
+				maniwg.Done()
 				return ctx.Err()
 			}
 		}


### PR DESCRIPTION
…ne() in this case the program can exit.

No improper side effects noticed, at least for the error, "Error waiting for zfs command to finish - exit status 1: WARNING: could not send X incremental source Y is not earlier than it"

This fixes issue #466 at least for this specific ZFS error that I encountered.
